### PR TITLE
Fix "command not found" error while running git aliases

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -32,6 +32,7 @@ zinit light zsh-users/zsh-autosuggestions
 zinit light Aloxaf/fzf-tab
 
 # Add in snippets
+zinit snippet OMZL::git.zsh
 zinit snippet OMZP::git
 zinit snippet OMZP::sudo
 zinit snippet OMZP::archlinux


### PR DESCRIPTION
## Problem

Running git aliases like `ggf` where `current_branch` is required, resulted in the below error: 

```bash
ggf:1: command not found: git_current_branch
fatal: invalid refspec '
```

Adding the committed line fixes the issue. 

