### PR TITLE
Fix fzf-tab not working properly

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -26,10 +26,10 @@ source "${ZINIT_HOME}/zinit.zsh"
 zinit ice depth=1; zinit light romkatv/powerlevel10k
 
 # Add in zsh plugins
+zinit light Aloxaf/fzf-tab
 zinit light zsh-users/zsh-syntax-highlighting
 zinit light zsh-users/zsh-completions
 zinit light zsh-users/zsh-autosuggestions
-zinit light Aloxaf/fzf-tab
 
 # Add in snippets
 zinit snippet OMZP::git


### PR DESCRIPTION
Simply load fzf-tab before other plugins, as loading it last was causing it to only work after initial plugin installation.